### PR TITLE
Prevent Script Closure, Improve ID Assignment, Improve Tree/Node Classes

### DIFF
--- a/Tree.js
+++ b/Tree.js
@@ -1,71 +1,87 @@
-// TO DO: restructure nodes array into a deque (doubly linked list)
-// currently, deleted nodes remain in memory (wasteful!!)
-
 // TO DO: transition to a Map object (guarantees iteration in insertion order)
 
-// import { TreeNode } from "./TreeNode.js";
+import { TreeNode } from "./TreeNode.js";
 
-class Tree {
+export class Tree {
   // nodes: an array of nodes, accessible by id
-  // nodeMap: an object of int:set(int) forming the tree
-
-  // if initializing a tree for the first time, id is whatever is free, maxId is 0,
-  // nodeMap is 0:empty-set, and nodes is [new TreeNode()] with default args
-  constructor(id, maxId, nodeMap, nodes) {
+  // nodeMap: an object of int-as-a-string:set(int-as-a-string) forming the tree
+  // freedIds: ids released by node deletion
+  constructor(id, nodeMap, nodes) {
     this.id = id;
-    this.maxId = maxId;
-    this.nodeMap = nodeMap;
-    this.nodes = nodes;
+    this.freedIds = [];
+    if (Object.keys(obj).length === 0) {
+      this.nodeMap = { 0: new Set() };
+    } else {
+      this.nodeMap = nodeMap;
+    }
+    if (nodes.length === 0) {
+      this.nodes = [new TreeNode(0, -1, "Root", new Date(), "Root", "")];
+    } else {
+      this.nodes = nodes;
+    }
   }
 
-  getMaxId() {
-    this.maxId++;
-    return this.maxId;
+  getUniqueId() {
+    if (this.freedIds.length > 0) {
+      return this.freedIds.pop();
+    } else {
+      return this.nodes.length + 1;
+    }
   }
 
   addNode(newNode) {
-    this.nodes.append(newNode);
-    this.nodeMap[newNode.id] = set();
-    this.nodeMap[newNode.parentId].add(newNode.id);
+    this.nodes[newNode.id] = newNode;
+    this.nodeMap[str(newNode.id)] = set();
+    this.nodeMap[str(newNode.parentId)].add(str(newNode.id));
   }
 
+  // TO-DO: check if nodeId is in freedIds (invalid)
+
   deleteNode(nodeId) {
-    if (nodeId < 0 || nodeId >= this.nodes.length) {
+    if (nodeId <= 0 || nodeId >= this.nodes.length) {
       console.log("Invalid Id.");
+      return;
     }
 
     let temp = nodes[nodeId];
-    this.nodes[nodeId] = null;
-    this.nodeMap[temp.parentId].delete(nodeId);
-    this.nodes[nodeId].children.foreach((id) => nodeMap[temp.parentId].add(id));
-    delete nodeMap[nodeId];
+    this.nodes[nodeId] = new TreeNode(-1, -1, "", new Date(), "", "");
+    this.freedIds.append(nodeId);
+    this.nodeMap[str(temp.parentId)].delete(str(nodeId));
+    this.nodeMap[str(nodeId)].foreach((id) =>
+      nodeMap[str(temp.parentId)].add(str(id))
+    );
+    delete nodeMap[str(nodeId)];
   }
 
+  // TO-DO: move node position within same parent
+
   moveNode(nodeId, newParentId) {
-    if (nodeId < 0 || nodeId >= this.nodes.length) {
+    if (nodeId <= 0 || nodeId >= this.nodes.length) {
       console.log("Invalid Id.");
+      return;
     }
     if (newParentId < 0 || newParentId >= this.nodes.length) {
       console.log("Invalid Parent Id.");
+      return;
     }
     let temp = nodes[nodeId];
-    this.nodeMap[temp.parentId].delete(nodeId);
-    nodeMap[newParentId].add(nodeId);
+    this.nodeMap[str(temp.parentId)].delete(str(nodeId));
+    nodeMap[str(newParentId)].add(str(nodeId));
   }
 
   getNode(nodeId) {
-    if (nodeId < 0 || nodeId >= this.nodes.length) {
+    if (nodeId <= 0 || nodeId >= this.nodes.length) {
       console.log("Invalid Id.");
+      return null;
     }
     return nodes[nodeId];
   }
 
   editNode(nodeId, newNode) {
-    if (nodeId < 0 || nodeId >= this.nodes.length) {
+    if (nodeId <= 0 || nodeId >= this.nodes.length) {
       console.log("Invalid Id.");
+      return;
     }
     nodes[nodeId] = newNode;
   }
 }
-
-export { Tree };

--- a/Tree.js
+++ b/Tree.js
@@ -1,17 +1,19 @@
+// TO DO: restructure nodes array into a deque (doubly linked list)
+// currently, deleted nodes remain in memory (wasteful!!)
+
+// TO DO: transition to a Map object (guarantees iteration in insertion order)
+
+// import { TreeNode } from "./TreeNode.js";
+
 class Tree {
   // nodes: an array of nodes, accessible by id
   // nodeMap: an object of int:set(int) forming the tree
 
-  // for use when a tree is first made
-  constructor() {
-    this.id = 0;
-    this.nodeMap = {};
-    this.nodes = [];
-  }
-
-  // for use when a tree is recreated
-  constructor(id, nodeMap, nodes) {
+  // if initializing a tree for the first time, id is whatever is free, maxId is 0,
+  // nodeMap is 0:empty-set, and nodes is [new TreeNode()] with default args
+  constructor(id, maxId, nodeMap, nodes) {
     this.id = id;
+    this.maxId = maxId;
     this.nodeMap = nodeMap;
     this.nodes = nodes;
   }
@@ -30,13 +32,12 @@ class Tree {
   deleteNode(nodeId) {
     if (nodeId < 0 || nodeId >= this.nodes.length) {
       console.log("Invalid Id.");
-    };
+    }
 
     let temp = nodes[nodeId];
     this.nodes[nodeId] = null;
     this.nodeMap[temp.parentId].delete(nodeId);
-    this.nodes[nodeId].children.foreach((id) => 
-      nodeMap[temp.parentId].add(id));
+    this.nodes[nodeId].children.foreach((id) => nodeMap[temp.parentId].add(id));
     delete nodeMap[nodeId];
   }
 
@@ -66,3 +67,5 @@ class Tree {
     nodes[nodeId] = newNode;
   }
 }
+
+export { Tree };

--- a/TreeNode.js
+++ b/TreeNode.js
@@ -1,5 +1,6 @@
 class TreeNode {
-  constructor(parentId, url, timestamp, title, favicon) {
+  constructor(id, parentId, url, timestamp, title, favicon) {
+    this.id = id;
     this.parentId = parentId;
     this.url = url;
     this.timestamp = timestamp;
@@ -7,3 +8,5 @@ class TreeNode {
     this.favicon = favicon;
   }
 }
+
+export { TreeNode };

--- a/TreeNode.js
+++ b/TreeNode.js
@@ -1,4 +1,4 @@
-class TreeNode {
+export class TreeNode {
   constructor(id, parentId, url, timestamp, title, favicon) {
     this.id = id;
     this.parentId = parentId;
@@ -8,5 +8,3 @@ class TreeNode {
     this.favicon = favicon;
   }
 }
-
-export { TreeNode };

--- a/background.js
+++ b/background.js
@@ -53,3 +53,29 @@ chrome.runtime.onStartup.addListener(function () {
     console.log(result.activeTree);
   });
 });
+
+let keepAlivePort = null;
+
+function keepAlive() {
+  if (keepAlivePort) {
+    keepAlivePort.disconnect();
+  }
+
+  keepAlivePort = chrome.runtime.connect({ name: "keepBranchAlive" });
+  keepAlivePort.onDisconnect.addListener(keepAlive);
+
+  setInterval(() => {
+    if (keepAlivePort) {
+      keepAlivePort.postMessage({ type: "keepBranchAlive" });
+    }
+  }, 240000);
+}
+
+chrome.runtime.onConnect.addListener((port) => {
+  if (port.name === "keepBranchAlive") {
+    keepAlivePort = port;
+    port.onDisconnect.addListener(keepAlive);
+  }
+});
+
+keepAlive();

--- a/background.js
+++ b/background.js
@@ -1,0 +1,55 @@
+import { TreeNode } from "./TreeNode.js";
+import { Tree } from "./Tree.js";
+
+/*
+
+Background script:
+- Handle pages opened from new tab interface
+- Handle pages opened from right-click > open in new tab
+
+document.referrer will be empty in this case
+Event loop (new tab):
+- Get TreeNode info from new page
+- Parent ID will be 0 (root of tree)
+- Add the newly-created node to the tree
+
+Event loop (right click):
+- Get mostRecentLinkClickPageId from chrome.storage.session
+- Get TreeNode info from new page
+- Add the newly-created node to the tree
+- Implementing later
+
+*/
+
+chrome.runtime.onInstalled.addListener(() => {
+  chrome.storage.session.setAccessLevel({
+    accessLevel: "TRUSTED_AND_UNTRUSTED_CONTEXTS",
+  });
+  console.log("Permissions for content scripts modified.");
+});
+
+chrome.runtime.onStartup.addListener(function () {
+  console.log("Startup script launching.");
+  const emptySet = new Set();
+  const newTree = {
+    id: 0,
+    maxId: 0,
+    nodeMap: { 0: [] },
+    nodes: [
+      {
+        id: 0,
+        parentId: -1,
+        url: "",
+        timestamp: new Date(),
+        title: "",
+        favicon: "",
+      },
+    ],
+  };
+  console.log(newTree);
+  chrome.storage.session.set({ activeTree: newTree });
+  chrome.storage.session.set({ previousPageId: 0 });
+  chrome.storage.session.get("activeTree", function (result) {
+    console.log(result.activeTree);
+  });
+});

--- a/branch.html
+++ b/branch.html
@@ -1,76 +1,85 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>branch</title>
-    <link rel="stylesheet" href="bulma.min.css"/>
-    <style> 
-      .title-container { 
-        display: flex; 
-        align-items: center; 
-        white-space: nowrap;  /* Ensures the text stays on one line */
-        overflow: hidden;     /* Hides any overflow */
-      } 
-      .title-container .title { 
-          margin-right: 1px; /* Adds some space between the title and the image */ 
+    <link rel="stylesheet" href="bulma.min.css" />
+    <style>
+      .title-container {
+        display: flex;
+        align-items: center;
+        white-space: nowrap; /* Ensures the text stays on one line */
+        overflow: hidden; /* Hides any overflow */
       }
-      .flex-container { 
-        display: flex; 
-        justify-content: space-between; 
-        align-items: center; 
+      .title-container .title {
+        margin-right: 1px; /* Adds some space between the title and the image */
+      }
+      .flex-container {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
       }
     </style>
-</head>
-<body>
-<section>
-   <div class="px-1 py-1">  <!--padding for entire menu -->
-      <section class="section"> 
-        <div class="container"> 
-          <article class="media title-container"> 
-            <div class="media-content"> 
-              <h1 class="title is-size-3">BRANCH</h1> 
-            </div> 
-            <figure class="media-right"> 
-              <p class="image is-16x16"> 
-                <img src="branchLogo.png" alt="Example Image"> 
-              </p> 
-            </figure> 
-          </article> 
-        </div>
-      </section>
+  </head>
+  <body>
+    <section>
+      <div class="px-1 py-1">
+        <!--padding for entire menu -->
+        <section class="section">
+          <div class="container">
+            <article class="media title-container">
+              <div class="media-content">
+                <h1 class="title is-size-3">BRANCH</h1>
+              </div>
+              <figure class="media-right">
+                <p class="image is-16x16">
+                  <img src="branchLogo.png" alt="Example Image" />
+                </p>
+              </figure>
+            </article>
+          </div>
+        </section>
 
-        <div class="box p-3"> <!--first node-->
-          <h1 class="title is-size-6"> sample tree node </h1> <!--node title-->
-            <div class="container">
-                <div class="flex-container">
-                    <p class="is-size-7"># nodes</p>
-                    <p class="is-size-7">last node visited 10/12/24</p>
-                </div>
+        <div class="box p-3">
+          <!--first node-->
+          <h1 class="title is-size-6">sample tree node</h1>
+          <!--node title-->
+          <div class="container">
+            <div class="flex-container">
+              <p class="is-size-7"># nodes</p>
+              <p class="is-size-7">last node visited 10/12/24</p>
             </div>
-        </div>
-        
-
-        <div class="box p-3"> <!--second node-->
-          <h1 class="title is-size-6"> sample tree node </h1> <!--node title-->
-            <div class="container">
-                <div class="flex-container">
-                    <p class="is-size-7"># nodes</p>
-                    <p class="is-size-7">last node visited 10/12/24</p>
-                </div>
-            </div>
+          </div>
         </div>
 
-        <div class="box p-3"> <!--third node-->
-          <h1 class="title is-size-6"> sample tree node </h1> <!--node title-->
-            <div class="container">
-                <div class="flex-container">
-                    <p class="is-size-7"># nodes</p>
-                    <p class="is-size-7">last node visited 10/12/24</p>
-                </div>
+        <div class="box p-3">
+          <!--second node-->
+          <h1 class="title is-size-6">sample tree node</h1>
+          <!--node title-->
+          <div class="container">
+            <div class="flex-container">
+              <p class="is-size-7"># nodes</p>
+              <p class="is-size-7">last node visited 10/12/24</p>
             </div>
+          </div>
         </div>
-    </div>
-    <!-- <script src="branchTest.js"></script> -->
-</body>
+
+        <div class="box p-3">
+          <!--third node-->
+          <h1 class="title is-size-6">sample tree node</h1>
+          <!--node title-->
+          <div class="container">
+            <div class="flex-container">
+              <p class="is-size-7"># nodes</p>
+              <p class="is-size-7">last node visited 10/12/24</p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <input type="button" value="Open Tree Render" id="render-page-btn" />
+    </section>
+    <script src="branchTest.js"></script>
+  </body>
 </html>

--- a/branchTest.js
+++ b/branchTest.js
@@ -1,21 +1,3 @@
-// function postKey() {
-//   let devKey = prompt("Please enter an ID.");
-//   let devName = prompt("Please enter your name.");
-
-//   let obj = {};
-//   obj[devKey] = devName;
-
-//   chrome.storage.sync
-//     .set(obj)
-//     .then(() => {
-//       console.log("Key value pair created.");
-//     })
-//     .then(() => {
-//       console.log(devKey);
-//       chrome.storage.sync.get([devKey.toString()]).then((result) => {
-//         console.log("Result is " + JSON.stringify(result));
-//       });
-//     });
-// }
-
-// postKey();
+document.getElementById("render-page-btn").addEventListener("click", () => {
+  chrome.tabs.create({ url: chrome.runtime.getURL("treeRender.html") });
+});

--- a/content.js
+++ b/content.js
@@ -89,3 +89,11 @@ document.addEventListener("click", function (event) {
   chrome.storage.session.set({ previousPageId: pageId });
   // give 200ms for the page ID to be stored, then navigate
 });
+
+const port = chrome.runtime.connect({ name: "keepBranchAlive" });
+
+port.onMessage.addListener((msg) => {
+  if (msg.type === "keepBranchAlive") {
+    port.postMessage({ type: "acknowledged" });
+  }
+});

--- a/content.js
+++ b/content.js
@@ -1,0 +1,91 @@
+// TO-DO: right-clicks don't register as clicks...
+
+/*
+
+content script which runs on every page after load to
+- listen for page events
+- add itself to the tree
+- add page metadata
+- communicate with background script / storage as necessary
+
+content scripts
+- handle links clicked directly on a page
+- detect when right click occurs and store relevant info
+
+event loop (direct click):
+- detect link clicked (URL change)
+- get parent ID from page metadata and store in chrome.storage.session
+- get TreeNode info from new page, retrieve parent ID from chrome.storage.session
+- add the newly-created node to the tree
+
+event loop (right click):
+- detect contents of right-clicked node
+- write link to "mostRecentLinkClickPageId" in chrome.storage.session
+- implementing later
+
+*/
+
+document.addEventListener("DOMContentLoaded", function () {
+  chrome.storage.session.get("activeTree", function (result1) {
+    // fetch the tree
+    let activeTree = result1.activeTree;
+    console.log("Tree fetched.");
+    console.log(result1);
+
+    // add a meta tag to the page containing the node ID
+    const metaTag = document.createElement("meta");
+    metaTag.name = "page-id";
+    metaTag.content = activeTree.nodes.length;
+    document.head.appendChild(metaTag);
+
+    chrome.storage.session.get("previousPageId", function (result2) {
+      // fetch the parent ID (ID from page where link was clicked)
+      let parentId = result2.previousPageId;
+      // if new page was not opened by a link click
+      if (document.referrer === "") {
+        console.log("Parent ID set to 0.");
+        parentId = 0;
+      }
+      console.log("Previous page ID fetched.");
+      console.log(result2.previousPageId);
+      // fetch the URL of the favicon from among the link tags
+      let faviconUrl = "";
+      const linkTags = document.getElementsByTagName("link");
+      for (let link of linkTags) {
+        if (link.rel === "icon" || link.rel === "shortcut icon") {
+          faviconUrl = link.href;
+          break;
+        }
+      }
+
+      // construct a new node from the previous info
+      let newNode = {
+        id: activeTree.nodes.length,
+        parentId: parentId,
+        url: document.location.href,
+        timestamp: new Date(),
+        title: document.title,
+        favicon: faviconUrl,
+      };
+
+      // add the node to the tree
+      activeTree.nodes.push(newNode);
+      activeTree.nodeMap[newNode.id] = [];
+      activeTree.nodeMap[newNode.parentId].push(newNode.id);
+
+      console.log(activeTree);
+
+      // write the tree back to chrome.storage.session
+      chrome.storage.session.set({ activeTree: activeTree });
+    });
+  });
+});
+
+// general click event listener for entire page
+document.addEventListener("click", function (event) {
+  // get the page id from the meta element named page-id inside head
+  const pageId = document.querySelector('head meta[name="page-id"]').content;
+  console.log(pageId);
+  chrome.storage.session.set({ previousPageId: pageId });
+  // give 200ms for the page ID to be stored, then navigate
+});

--- a/manifest.JSON
+++ b/manifest.JSON
@@ -9,12 +9,21 @@
     "default_icon": "branchLogo.png"
   },
 
-  "icons":{
-    "16": "images/branchLogo.png"
+  "icons": {
+    "16": "./branchLogo.png"
   },
 
-  "background":{
+  "background": {
     "service_worker": "background.js",
     "type": "module"
   },
+
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["content.js"],
+      "run_at": "document_start",
+      "type": "module"
+    }
+  ]
 }

--- a/treeRender.html
+++ b/treeRender.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Tree Rendering</title>
+  </head>
+  <body>
+    <h1>Tree Render Proof of Concept</h1>
+    <input type="button" value="Render Tree" id="render-btn" />
+    <ul id="root"></ul>
+    <script src="treeRender.js"></script>
+  </body>
+</html>

--- a/treeRender.js
+++ b/treeRender.js
@@ -1,0 +1,61 @@
+// write function for depth-first traversal
+
+// tree rendered as unordered list
+// each item is a list item followed by a possibly empty unordered list
+
+document.getElementById("render-btn").addEventListener("click", renderTree);
+
+var depth = 0;
+var nodeList = [];
+
+async function renderTree() {
+  // Reset recursion values
+  depth = 0;
+  nodeList = [];
+
+  // Fetch active tree
+  chrome.storage.session.get("activeTree", function (result) {
+    activeTree = result.activeTree;
+
+    // DFS tree, place results including indents in nodeList
+    dfs(0, activeTree.nodeMap, activeTree.nodes);
+
+    console.log(nodeList);
+
+    console.log("Now attaching children");
+
+    var root = document.getElementById("root");
+
+    nodeList.forEach((element) => {
+      let newNode = document.createElement("li");
+      let indentText = "";
+      for (let step = 0; step < element[1] - 1; step++) {
+        indentText += "☆    ";
+      }
+      newNode.innerHTML = indentText + element[0];
+      root.appendChild(newNode);
+    });
+
+    root.removeChild(root.firstChild);
+  });
+}
+
+function dfs(id, map, list) {
+  nodeList.push([list[id].title, depth]);
+
+  depth += 1;
+
+  map[id].forEach((element) => {
+    dfs(element, map, list);
+  });
+
+  depth -= 1;
+}
+
+/*
+
+L Wikipedia
+L____ Pasadena
+L________ LA County
+
+*/


### PR DESCRIPTION
The background script should now remain alive indefinitely. This means reading/writing from long-term storage only needs to happen when Chrome opens and closes (and if the script is forcefully unloaded by Chrome, which should be rare).

ID assignment now accounts for deleted nodes and recycles IDs.

NodeMap now uses ints-as-strings, which preserves insertion order.